### PR TITLE
Fix this.connected bug when connect event is missed

### DIFF
--- a/lib/ExpressRedisCache.js
+++ b/lib/ExpressRedisCache.js
@@ -96,6 +96,10 @@ module.exports = (function () {
         this.emit('disconnected', { host: this.host, port: this.port });
         this.emit('message', 'Disconnected from redis://' + this.client.host + ':' + this.client.port);
       }.bind(this));
+      
+      if ( this.client.connected ) {
+        this.client.emit('connect')
+      }
     }
   }
 


### PR DESCRIPTION
This PR fix a bug that this.connected is not initialized if the redis connect event is missed.

Check if the connect event is missed or not, then emit the missed connect event again.