### PR TITLE
Fix bug a race condition this.connected never initialized

### DIFF
--- a/lib/ExpressRedisCache.js
+++ b/lib/ExpressRedisCache.js
@@ -85,11 +85,13 @@ module.exports = (function () {
         this.emit('error', error);
       }.bind(this));
 
-      this.client.on('connect', function () {
+      function onConnect() {
         this.connected = true;
         this.emit('connected', { host: this.host, port: this.port });
         this.emit('message', 'OK connected to redis://' + this.client.address);
-      }.bind(this));
+      }
+      this.client.on('connect', onConnect.bind(this));
+
 
       this.client.on('end', function () {
         this.connected = false;
@@ -97,8 +99,8 @@ module.exports = (function () {
         this.emit('message', 'Disconnected from redis://' + this.client.host + ':' + this.client.port);
       }.bind(this));
       
-      if ( this.client.connected ) {
-        this.client.emit('connect');
+      if ( !this.connected && this.client.connected ) {
+        onConnect()
       }
     }
   }


### PR DESCRIPTION
Fix a race condition that this.connected would never be initialized if the 'connect' event emitted before the on-event handler is registered.

Avoid resenting the redis 'connect' event by suggested changes.